### PR TITLE
feat: configure CORS via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 OLLAMA_ENABLED=true
 OLLAMA_BASE_URL=http://localhost:11434
+CORS_ALLOWED_ORIGINS=http://localhost:3000,https://example.com,https://*.example.com

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Create a `.env` file in the root directory of this project and configure your pr
 # General Configuration
 DEFAULT_ACCESS_TOKEN=your-secret-api-key
 
+# CORS Configuration
+CORS_ALLOWED_ORIGINS=http://localhost:3000,https://example.com,https://*.example.com
+
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key
 


### PR DESCRIPTION
## Summary
- allow configuring CORS origins via CORS_ALLOWED_ORIGINS
- document new CORS settings in README and env example

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897124c8d94832da03995a92c4f2f76