### PR TITLE
feat: enhance demo templates with metrics display

### DIFF
--- a/src/templates/emailReplyDemo.html
+++ b/src/templates/emailReplyDemo.html
@@ -25,6 +25,38 @@
     .loading-dot:nth-child(1) { animation-delay: -0.32s; }
     .loading-dot:nth-child(2) { animation-delay: -0.16s; }
     @keyframes bounce { 0%, 80%, 100% { transform: scale(0); opacity: 0.5; } 40% { transform: scale(1); opacity: 1; } }
+    
+    .metrics-container {
+      background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+      border-radius: 12px;
+      padding: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .metric-item {
+      background: white;
+      padding: 8px 12px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .metric-icon {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .metric-label {
+      font-size: 12px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-size: 14px;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body class="bg-white min-h-screen">
@@ -244,25 +276,84 @@
       loadingIndicator.classList.remove('hidden');
       replyText.textContent = '';
       usageInfo.classList.add('hidden'); usageInfo.innerHTML = '';
+      
+      const startTime = performance.now();
+      
       try {
         const res = await fetch('/api/v1/emailReply', { method: 'POST', headers, body: JSON.stringify(req), signal: abortController.signal });
+        const endTime = performance.now();
+        const responseTime = (endTime - startTime).toFixed(2);
+        
         if (!res.ok) { const txt = await res.text(); throw new Error('Request failed: ' + res.status + ' ' + txt); }
         const data = await res.json();
         const reply = data?.reply || data?.data?.reply || '';
         replyText.textContent = reply || 'No reply returned.';
-        const usage = data?.usage || data?.data?.usage; 
+        const usage = data?.usage || data?.data?.usage;
+        usageInfo.classList.remove('hidden');
+        
+        let metricsHtml = '<div class="metrics-container">';
+        metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
+        
+        // Response Time metric
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Response</div>' +
+            '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+          '</div>' +
+        '</div>';
+        
         if (usage) {
           const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
           const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
           const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
-          usageInfo.classList.remove('hidden');
-          usageInfo.innerHTML = '<div class="flex items-center gap-4 text-sm">' +
-            '<span class="text-gray-500">Tokens:</span>' +
-            '<span class="font-medium">Input: <span class="text-blue-600">' + inputTokens + '</span></span>' +
-            '<span class="font-medium">Output: <span class="text-green-600">' + outputTokens + '</span></span>' +
-            '<span class="font-medium">Total: <span class="text-purple-600">' + totalTokens + '</span></span>' +
+          
+          // Input Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Input</div>' +
+              '<div class="metric-value text-blue-600">' + inputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Output Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Output</div>' +
+              '<div class="metric-value text-green-600">' + outputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Total Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Total</div>' +
+              '<div class="metric-value text-purple-600">' + totalTokens.toLocaleString() + '</div>' +
+            '</div>' +
           '</div>';
         }
+        
+        metricsHtml += '</div></div>';
+        usageInfo.innerHTML = metricsHtml;
       } catch (err) {
         replyText.textContent = err.message || 'Unknown error';
         usageInfo.classList.add('hidden'); usageInfo.innerHTML = '';

--- a/src/templates/highlighterDemo.html
+++ b/src/templates/highlighterDemo.html
@@ -46,6 +46,38 @@
       0%, 80%, 100% { transform: scale(0); opacity: 0.5; }
       40% { transform: scale(1); opacity: 1; }
     }
+    
+    .metrics-container {
+      background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+      border-radius: 12px;
+      padding: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .metric-item {
+      background: white;
+      padding: 8px 12px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .metric-icon {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .metric-label {
+      font-size: 12px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-size: 14px;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body class="bg-white min-h-screen">
@@ -155,10 +187,8 @@
       <!-- Output -->
       <section class="bg-white p-6 rounded-2xl border border-gray-100 shadow-lg hover:shadow-xl transition-shadow duration-300">
         <h2 class="text-lg font-semibold mb-3">Output</h2>
-        <div class="mb-3 text-sm text-gray-600 flex items-center gap-3">
-          <div id="usageInfo" class="hidden"></div>
-          <div id="labelLegend" class="flex flex-wrap gap-2"></div>
-        </div>
+        <div id="usageInfo" class="hidden mb-3"></div>
+        <div id="labelLegend" class="flex flex-wrap gap-2 mb-3"></div>
         <div id="renderedText" class="p-4 rounded-lg bg-gray-50 border border-gray-200 leading-7"></div>
         <div class="mt-4">
           <h3 class="font-medium text-gray-900 mb-2">Highlights</h3>
@@ -321,6 +351,8 @@
       usageInfo.classList.add('hidden');
       summaryLine.textContent = '';
       
+      const startTime = performance.now();
+      
       try {
         const res = await fetch('/api/v1/highlighter', { 
           method: 'POST', 
@@ -328,6 +360,9 @@
           body: JSON.stringify(req),
           signal: abortController.signal
         });
+        const endTime = performance.now();
+        const responseTime = (endTime - startTime).toFixed(2);
+        
         if (!res.ok) {
           const txt = await res.text();
           throw new Error('Request failed: ' + res.status + ' ' + txt);
@@ -353,21 +388,71 @@
         labelLegend.innerHTML = Object.entries(counts).map(([label, count]) => { const c = colorFor(label); return '<span class="label-pill ' + c.pill + '">' + escapeHtml(label) + '<span class="text-gray-500">(' + count + ')</span></span>'; }).join('');
         // Usage - handle different response formats
         const usage = data?.usage || data?.data?.usage;
+        usageInfo.classList.remove('hidden');
+        
+        let metricsHtml = '<div class="metrics-container">';
+        metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
+        
+        // Response Time metric
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Response</div>' +
+            '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+          '</div>' +
+        '</div>';
+        
         if (usage) {
-          usageInfo.classList.remove('hidden');
           const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
           const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
           const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
           
-          usageInfo.innerHTML = '<div class="flex items-center gap-4 text-sm">' +
-            '<span class="text-gray-500">Tokens:</span>' +
-            '<span class="font-medium">Input: <span class="text-blue-600">' + inputTokens + '</span></span>' +
-            '<span class="font-medium">Output: <span class="text-green-600">' + outputTokens + '</span></span>' +
-            '<span class="font-medium">Total: <span class="text-purple-600">' + totalTokens + '</span></span>' +
-            '</div>';
-        } else {
-          usageInfo.classList.add('hidden');
+          // Input Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Input</div>' +
+              '<div class="metric-value text-blue-600">' + inputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Output Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Output</div>' +
+              '<div class="metric-value text-green-600">' + outputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Total Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Total</div>' +
+              '<div class="metric-value text-purple-600">' + totalTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
         }
+        
+        metricsHtml += '</div></div>';
+        usageInfo.innerHTML = metricsHtml;
         // Summary
         summaryLine.textContent = 'Conversation Analysis: ' + highlights.length + ' key highlights identified';
       } catch (err) {

--- a/src/templates/keywordsDemo.html
+++ b/src/templates/keywordsDemo.html
@@ -24,6 +24,38 @@
     .loading-dot:nth-child(1) { animation-delay: -0.32s; }
     .loading-dot:nth-child(2) { animation-delay: -0.16s; }
     @keyframes bounce { 0%, 80%, 100% { transform: scale(0); opacity: 0.5; } 40% { transform: scale(1); opacity: 1; } }
+    
+    .metrics-container {
+      background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+      border-radius: 12px;
+      padding: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .metric-item {
+      background: white;
+      padding: 8px 12px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .metric-icon {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .metric-label {
+      font-size: 12px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-size: 14px;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body class="bg-white min-h-screen">
@@ -208,25 +240,82 @@
       jsonPreview.textContent = JSON.stringify(req, null, 2);
     }
 
-    function renderUsage(usage) {
-      if (!usage) { usageInfo.classList.add('hidden'); usageInfo.innerHTML = ''; return; }
+    function renderUsage(usage, responseTime) {
+      if (!usage && !responseTime) { usageInfo.classList.add('hidden'); usageInfo.innerHTML = ''; return; }
       usageInfo.classList.remove('hidden');
-      const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
-      const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
-      const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
-      usageInfo.innerHTML = '<div class="flex items-center gap-4 text-sm">' +
-        '<span class="text-gray-500">Tokens:</span>' +
-        '<span class="font-medium">Input: <span class="text-blue-600">' + inputTokens + '</span></span>' +
-        '<span class="font-medium">Output: <span class="text-green-600">' + outputTokens + '</span></span>' +
-        '<span class="font-medium">Total: <span class="text-purple-600">' + totalTokens + '</span></span>' +
-      '</div>';
+      
+      let metricsHtml = '<div class="metrics-container">';
+      metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
+      
+      // Response Time metric
+      if (responseTime) {
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Response</div>' +
+            '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+          '</div>' +
+        '</div>';
+      }
+      
+      if (usage) {
+        const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
+        const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
+        const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
+        
+        // Input Tokens
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Input</div>' +
+            '<div class="metric-value text-blue-600">' + inputTokens.toLocaleString() + '</div>' +
+          '</div>' +
+        '</div>';
+        
+        // Output Tokens
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Output</div>' +
+            '<div class="metric-value text-green-600">' + outputTokens.toLocaleString() + '</div>' +
+          '</div>' +
+        '</div>';
+        
+        // Total Tokens
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Total</div>' +
+            '<div class="metric-value text-purple-600">' + totalTokens.toLocaleString() + '</div>' +
+          '</div>' +
+        '</div>';
+      }
+      
+      metricsHtml += '</div></div>';
+      usageInfo.innerHTML = metricsHtml;
     }
 
-    function renderResult(data) {
+    function renderResult(data, responseTime) {
       const keywords = data?.keywords || data?.data?.keywords || [];
       keywordsList.innerHTML = keywords.map(k => '<li class="p-3 bg-gray-50 border border-gray-200 rounded-lg">' + String(k) + '</li>').join('');
       const usage = data?.usage || data?.data?.usage;
-      renderUsage(usage);
+      renderUsage(usage, responseTime);
     }
 
     async function run() {
@@ -242,11 +331,17 @@
       keywordsList.innerHTML = '';
       usageInfo.classList.add('hidden');
       usageInfo.innerHTML = '';
+      
+      const startTime = performance.now();
+      
       try {
         const res = await fetch('/api/v1/keywords', { method: 'POST', headers, body: JSON.stringify(req), signal: abortController.signal });
+        const endTime = performance.now();
+        const responseTime = (endTime - startTime).toFixed(2);
+        
         if (!res.ok) { const txt = await res.text(); throw new Error('Request failed: ' + res.status + ' ' + txt); }
         const data = await res.json();
-        renderResult(data);
+        renderResult(data, responseTime);
       } catch (err) {
         keywordsList.innerHTML = '<li class="text-red-600">' + (err.message || 'Unknown error') + '</li>';
         usageInfo.classList.add('hidden'); usageInfo.innerHTML = '';

--- a/src/templates/sentimentDemo.html
+++ b/src/templates/sentimentDemo.html
@@ -27,6 +27,38 @@
     .loading-dot:nth-child(1) { animation-delay: -0.32s; }
     .loading-dot:nth-child(2) { animation-delay: -0.16s; }
     @keyframes bounce { 0%, 80%, 100% { transform: scale(0); opacity: 0.5; } 40% { transform: scale(1); opacity: 1; } }
+    
+    .metrics-container {
+      background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+      border-radius: 12px;
+      padding: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .metric-item {
+      background: white;
+      padding: 8px 12px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .metric-icon {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .metric-label {
+      font-size: 12px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-size: 14px;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body class="bg-white min-h-screen">
@@ -233,21 +265,78 @@
       updatePreview();
     }
 
-    function renderUsage(usage) {
-      if (!usage) { usageInfo.classList.add('hidden'); usageInfo.innerHTML = ''; return; }
+    function renderUsage(usage, responseTime) {
+      if (!usage && !responseTime) { usageInfo.classList.add('hidden'); usageInfo.innerHTML = ''; return; }
       usageInfo.classList.remove('hidden');
-      const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
-      const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
-      const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
-      usageInfo.innerHTML = '<div class="flex items-center gap-4 text-sm">' +
-        '<span class="text-gray-500">Tokens:</span>' +
-        '<span class="font-medium">Input: <span class="text-blue-600">' + inputTokens + '</span></span>' +
-        '<span class="font-medium">Output: <span class="text-green-600">' + outputTokens + '</span></span>' +
-        '<span class="font-medium">Total: <span class="text-purple-600">' + totalTokens + '</span></span>' +
-      '</div>';
+      
+      let metricsHtml = '<div class="metrics-container">';
+      metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
+      
+      // Response Time metric
+      if (responseTime) {
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Response</div>' +
+            '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+          '</div>' +
+        '</div>';
+      }
+      
+      if (usage) {
+        const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
+        const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
+        const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
+        
+        // Input Tokens
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Input</div>' +
+            '<div class="metric-value text-blue-600">' + inputTokens.toLocaleString() + '</div>' +
+          '</div>' +
+        '</div>';
+        
+        // Output Tokens
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Output</div>' +
+            '<div class="metric-value text-green-600">' + outputTokens.toLocaleString() + '</div>' +
+          '</div>' +
+        '</div>';
+        
+        // Total Tokens
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Total</div>' +
+            '<div class="metric-value text-purple-600">' + totalTokens.toLocaleString() + '</div>' +
+          '</div>' +
+        '</div>';
+      }
+      
+      metricsHtml += '</div></div>';
+      usageInfo.innerHTML = metricsHtml;
     }
 
-    function renderResult(data) {
+    function renderResult(data, responseTime) {
       const sentiment = data?.sentiment || data?.data?.sentiment || '';
       const confidence = data?.confidence ?? data?.data?.confidence;
       const emotions = data?.emotions || data?.data?.emotions || [];
@@ -261,7 +350,7 @@
         '</li>'
       }).join('');
       const usage = data?.usage || data?.data?.usage;
-      renderUsage(usage);
+      renderUsage(usage, responseTime);
     }
 
     async function run() {
@@ -281,14 +370,19 @@
       usageInfo.classList.add('hidden');
       usageInfo.innerHTML = '';
 
+      const startTime = performance.now();
+
       try {
         const res = await fetch('/api/v1/sentiment', { method: 'POST', headers, body: JSON.stringify(req), signal: abortController.signal });
+        const endTime = performance.now();
+        const responseTime = (endTime - startTime).toFixed(2);
+        
         if (!res.ok) {
           const txt = await res.text();
           throw new Error('Request failed: ' + res.status + ' ' + txt);
         }
         const data = await res.json();
-        renderResult(data);
+        renderResult(data, responseTime);
       } catch (err) {
         emotionsList.innerHTML = '<li class="text-red-600">' + (err.message || 'Unknown error') + '</li>';
         usageInfo.classList.add('hidden');

--- a/src/templates/summarizeDemo.html
+++ b/src/templates/summarizeDemo.html
@@ -22,6 +22,39 @@
       }
     }
   </script>
+  <style>
+    .metrics-container {
+      background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+      border-radius: 12px;
+      padding: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .metric-item {
+      background: white;
+      padding: 8px 12px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .metric-icon {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .metric-label {
+      font-size: 12px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-size: 14px;
+      font-weight: 600;
+    }
+  </style>
 </head>
 <body class="bg-white min-h-screen">
   <!-- Navigation -->
@@ -268,6 +301,8 @@
       usageInfo.classList.add('hidden');
       usageInfo.innerHTML = '';
 
+      const startTime = performance.now();
+
       try {
         const res = await fetch('/api/v1/summarize', {
           method: 'POST',
@@ -275,6 +310,9 @@
           body: JSON.stringify(req),
           signal: abortController.signal
         });
+        const endTime = performance.now();
+        const responseTime = (endTime - startTime).toFixed(2);
+        
         if (!res.ok) {
           const txt = await res.text();
           throw new Error('Request failed: ' + res.status + ' ' + txt);
@@ -284,18 +322,71 @@
         summaryText.textContent = summary || 'No summary returned.';
 
         const usage = data?.usage || data?.data?.usage;
+        usageInfo.classList.remove('hidden');
+        
+        let metricsHtml = '<div class="metrics-container">';
+        metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
+        
+        // Response Time metric
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Response</div>' +
+            '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+          '</div>' +
+        '</div>';
+        
         if (usage) {
-          usageInfo.classList.remove('hidden');
           const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
           const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
           const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
-          usageInfo.innerHTML = '<div class="flex items-center gap-4 text-sm">' +
-            '<span class="text-gray-500">Tokens:</span>' +
-            '<span class="font-medium">Input: <span class="text-blue-600">' + inputTokens + '</span></span>' +
-            '<span class="font-medium">Output: <span class="text-green-600">' + outputTokens + '</span></span>' +
-            '<span class="font-medium">Total: <span class="text-purple-600">' + totalTokens + '</span></span>' +
+          
+          // Input Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Input</div>' +
+              '<div class="metric-value text-blue-600">' + inputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Output Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Output</div>' +
+              '<div class="metric-value text-green-600">' + outputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Total Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Total</div>' +
+              '<div class="metric-value text-purple-600">' + totalTokens.toLocaleString() + '</div>' +
+            '</div>' +
           '</div>';
         }
+        
+        metricsHtml += '</div></div>';
+        usageInfo.innerHTML = metricsHtml;
       } catch (err) {
         if (err.name === 'AbortError') {
           summaryText.innerHTML = '<div class="text-amber-600">Request cancelled by user</div>';

--- a/src/templates/translateDemo.html
+++ b/src/templates/translateDemo.html
@@ -25,6 +25,38 @@
     .loading-dot:nth-child(1) { animation-delay: -0.32s; }
     .loading-dot:nth-child(2) { animation-delay: -0.16s; }
     @keyframes bounce { 0%, 80%, 100% { transform: scale(0); opacity: 0.5; } 40% { transform: scale(1); opacity: 1; } }
+    
+    .metrics-container {
+      background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+      border-radius: 12px;
+      padding: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .metric-item {
+      background: white;
+      padding: 8px 12px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+    .metric-icon {
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .metric-label {
+      font-size: 12px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-size: 14px;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body class="bg-white min-h-screen">
@@ -75,8 +107,8 @@
             <label class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
             <select id="targetLanguageSelect" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple mb-2">
               <option value="">Select a language...</option>
+              <option value="Chinese" selected>Chinese</option>
               <option value="Tagalog">Tagalog</option>
-              <option value="Chinese">Chinese</option>
               <option value="Japanese">Japanese</option>
               <option value="Korean">Korean</option>
               <option value="French">French</option>
@@ -89,7 +121,7 @@
               <option value="Hindi">Hindi</option>
               <option value="__custom">Other (type)</option>
             </select>
-            <input id="targetLanguage" type="text" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple" placeholder="Type a language (e.g. Italian)" />
+            <input id="targetLanguage" type="text" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple disabled:bg-gray-50 disabled:cursor-not-allowed" placeholder="Select 'Other' above to type a custom language" disabled />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Temperature</label>
@@ -138,7 +170,7 @@
 
   <script>
     const samplePayload = {
-      payload: { text: "Good morning, how are you?", targetLanguage: "Spanish" },
+      payload: { text: "Good morning, how are you?", targetLanguage: "Chinese" },
       config: { provider: "openai", model: "gpt-4o-mini", temperature: 0 }
     };
 
@@ -224,26 +256,85 @@
       translationText.textContent = '';
       openInGoogleBtn.disabled = true;
       usageInfo.classList.add('hidden'); usageInfo.innerHTML = '';
+      
+      const startTime = performance.now();
+      
       try {
         const res = await fetch('/api/v1/translate', { method: 'POST', headers, body: JSON.stringify(req), signal: abortController.signal });
+        const endTime = performance.now();
+        const responseTime = (endTime - startTime).toFixed(2);
+        
         if (!res.ok) { const txt = await res.text(); throw new Error('Request failed: ' + res.status + ' ' + txt); }
         const data = await res.json();
         const translation = data?.translation || data?.data?.translation || '';
         translationText.textContent = translation || 'No translation returned.';
         openInGoogleBtn.disabled = !translation;
-        const usage = data?.usage || data?.data?.usage; 
+        const usage = data?.usage || data?.data?.usage;
+        usageInfo.classList.remove('hidden');
+        
+        let metricsHtml = '<div class="metrics-container">';
+        metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
+        
+        // Response Time metric
+        metricsHtml += '<div class="metric-item">' +
+          '<div class="metric-icon">' +
+            '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+              '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+            '</svg>' +
+          '</div>' +
+          '<div>' +
+            '<div class="metric-label">Response</div>' +
+            '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+          '</div>' +
+        '</div>';
+        
         if (usage) {
           const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
           const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
           const totalTokens = usage.total_tokens || (inputTokens + outputTokens);
-          usageInfo.classList.remove('hidden');
-          usageInfo.innerHTML = '<div class="flex items-center gap-4 text-sm">' +
-            '<span class="text-gray-500">Tokens:</span>' +
-            '<span class="font-medium">Input: <span class="text-blue-600">' + inputTokens + '</span></span>' +
-            '<span class="font-medium">Output: <span class="text-green-600">' + outputTokens + '</span></span>' +
-            '<span class="font-medium">Total: <span class="text-purple-600">' + totalTokens + '</span></span>' +
+          
+          // Input Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Input</div>' +
+              '<div class="metric-value text-blue-600">' + inputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Output Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Output</div>' +
+              '<div class="metric-value text-green-600">' + outputTokens.toLocaleString() + '</div>' +
+            '</div>' +
+          '</div>';
+          
+          // Total Tokens
+          metricsHtml += '<div class="metric-item">' +
+            '<div class="metric-icon">' +
+              '<svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>' +
+              '</svg>' +
+            '</div>' +
+            '<div>' +
+              '<div class="metric-label">Total</div>' +
+              '<div class="metric-value text-purple-600">' + totalTokens.toLocaleString() + '</div>' +
+            '</div>' +
           '</div>';
         }
+        
+        metricsHtml += '</div></div>';
+        usageInfo.innerHTML = metricsHtml;
       } catch (err) {
         translationText.textContent = err.message || 'Unknown error';
         openInGoogleBtn.disabled = true;
@@ -287,16 +378,24 @@
 
     inputText.addEventListener('input', updatePreview);
     targetLanguageEl.addEventListener('input', () => {
-      if (targetLanguageEl.value && targetLanguageSelectEl.value !== '__custom') {
-        targetLanguageSelectEl.value = '__custom';
-      }
       updatePreview();
     });
     targetLanguageSelectEl.addEventListener('change', () => {
-      if (targetLanguageSelectEl.value && targetLanguageSelectEl.value !== '__custom') {
-        targetLanguageEl.value = targetLanguageSelectEl.value;
-      } else if (targetLanguageSelectEl.value === '') {
+      if (targetLanguageSelectEl.value === '__custom') {
+        // Enable the text field for custom input
+        targetLanguageEl.disabled = false;
         targetLanguageEl.value = '';
+        targetLanguageEl.placeholder = 'Type a language (e.g. Italian, Portuguese, etc.)';
+        targetLanguageEl.focus();
+      } else {
+        // Disable text field and use dropdown value
+        targetLanguageEl.disabled = true;
+        targetLanguageEl.placeholder = "Select 'Other' above to type a custom language";
+        if (targetLanguageSelectEl.value && targetLanguageSelectEl.value !== '') {
+          targetLanguageEl.value = targetLanguageSelectEl.value;
+        } else {
+          targetLanguageEl.value = '';
+        }
       }
       updatePreview();
     });
@@ -311,12 +410,21 @@
 
     function setFromSample() {
       inputText.value = samplePayload.payload.text;
-      targetLanguageEl.value = samplePayload.payload.targetLanguage;
+      
+      // Check if the sample language is in the dropdown
       if ([...targetLanguageSelectEl.options].some(o => o.value === samplePayload.payload.targetLanguage)) {
         targetLanguageSelectEl.value = samplePayload.payload.targetLanguage;
+        targetLanguageEl.value = samplePayload.payload.targetLanguage;
+        targetLanguageEl.disabled = true;
+        targetLanguageEl.placeholder = "Select 'Other' above to type a custom language";
       } else {
+        // It's a custom language
         targetLanguageSelectEl.value = '__custom';
+        targetLanguageEl.value = samplePayload.payload.targetLanguage;
+        targetLanguageEl.disabled = false;
+        targetLanguageEl.placeholder = 'Type a language (e.g. Italian, Portuguese, etc.)';
       }
+      
       providerEl.value = samplePayload.config.provider;
       updateModelOptions();
       modelEl.value = samplePayload.config.model;


### PR DESCRIPTION
- Added a metrics container to display response time and token usage across various demo templates (emailReplyDemo, highlighterDemo, keywordsDemo, sentimentDemo, summarizeDemo, translateDemo).
- Improved the rendering of usage information to include detailed metrics for input, output, and total tokens.
- Implemented performance measurement for API requests to show response times in the UI.