### PR TITLE
feat: add project planner demo endpoint to API security configuration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,7 @@ function configureApiSecurity(app: OpenAPIHono, tokenConfig: string) {
                 path === '/api/translate-demo' ||
                 path === '/api/meeting-notes-demo' ||
                 path === '/api/asktext-demo' ||
+                path === '/api/project-planner-demo' ||
                 path === '/api/models' ||
                 path === '/api/jsoneditor' ||
                 // Public read-only service catalog for demos


### PR DESCRIPTION
- Included '/api/project-planner-demo' in the API security configuration to allow access to the project planner demo endpoint.