### PR TITLE
Add PDF translation feature with new endpoint and demo

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,6 +55,7 @@ function configureApiSecurity(app: OpenAPIHono, tokenConfig: string) {
                 path === '/api/v1/project-planner-demo' ||
                 path === '/api/v1/outline-demo' ||
                 path === '/api/v1/pdf-summarizer-demo' ||
+                path === '/api/v1/pdf-translate-demo' ||
                 path === '/api/models' ||
                 path === '/api/jsoneditor' ||
                 // Public read-only service catalog for demos

--- a/src/config/models.json
+++ b/src/config/models.json
@@ -3,16 +3,16 @@
     "ollama": {
       "enabled": true,
       "models": [
-        { "name": "llama3.2:latest", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "translate", "outline"], "notes": "Meta Llama 3.2 general-purpose model." },
+        { "name": "llama3.2:latest", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "translate", "outline"], "notes": "Meta Llama 3.2 general-purpose model." },
         { "name": "qwen2.5-coder:latest", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "emailReply", "outline"], "notes": "Qwen 2.5 coder-optimized variant for code tasks." },
         { "name": "gemma2:2b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "meetingNotes", "outline"], "notes": "Gemma 2 small variant for lightweight tasks." },
-        { "name": "gemma3:4b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "askText", "translate", "meetingNotes", "outline"], "notes": "Gemma 3 small variant for lightweight tasks with Q&A support." },
+        { "name": "gemma3:4b", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "askText", "translate", "meetingNotes", "outline"], "notes": "Gemma 3 small variant for lightweight tasks with Q&A support." },
         { "name": "qwen2.5:0.5b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "outline"], "notes": "Qwen 2.5 0.5B parameter model for ultra-light workloads." },
         { "name": "qwen2.5:1.5b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "outline"], "notes": "Qwen 2.5 1.5B parameter model; balanced speed/quality." },
-        { "name": "qwen2.5:3b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "outline"], "notes": "Qwen 2.5 3B parameter model for stronger quality." },
+        { "name": "qwen2.5:3b", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "outline"], "notes": "Qwen 2.5 3B parameter model for stronger quality." },
         { "name": "qwen2.5:7b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "emailReply", "outline"], "notes": "Qwen 2.5 7B parameter model for higher quality." },        
-        { "name": "llama3.2:1b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Llama 3.2 1B tiny variant for edge/light usage." },
-        { "name": "llama3.2:3b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Llama 3.2 3B small variant." },
+        { "name": "llama3.2:1b", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Llama 3.2 1B tiny variant for edge/light usage." },
+        { "name": "llama3.2:3b", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Llama 3.2 3B small variant." },
         { "name": "gemma3:270m", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "outline"], "notes": "Gemma 3 270M instruct tuned; great for ultra-fast summarization on CPU." }
       ]
     },
@@ -20,47 +20,47 @@
       "enabled": true,
       "models": [
         { "name": "gemma-3-270m-it", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "outline"], "notes": "Gemma 3 270M instruct tuned; great for ultra-fast summarization on CPU." },
-        { "name": "llama-3.2-3b-instruct", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Llama 3.2 3B instruct; strong small model for summarization." },
-        { "name": "nvidia_nvidia-nemotron-nano-9b-v2", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "NVIDIA Nemotron Nano 9B v2; compact high-performance model." }
+        { "name": "llama-3.2-3b-instruct", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Llama 3.2 3B instruct; strong small model for summarization." },
+        { "name": "nvidia_nvidia-nemotron-nano-9b-v2", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "NVIDIA Nemotron Nano 9B v2; compact high-performance model." }
       ]
     },
     "openai": {
       "enabled": true,
       "models": [
-        { "name": "gpt-4o-mini", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI multimodal small model with vision support." },
-        { "name": "gpt-4.1-nano", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI lightweight model for fast, low-cost text tasks." },
-        { "name": "gpt-5-mini", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen mini model with Q&A capabilities." },
-        { "name": "gpt-5-nano", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen nano model with Q&A capabilities." },
-        { "name": "gpt-5", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen model with Q&A capabilities." },
-        { "name": "gpt-4o", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen vision model with Q&A capabilities." }
+        { "name": "gpt-4o-mini", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI multimodal small model with vision support." },
+        { "name": "gpt-4.1-nano", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI lightweight model for fast, low-cost text tasks." },
+        { "name": "gpt-5-mini", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen mini model with Q&A capabilities." },
+        { "name": "gpt-5-nano", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen nano model with Q&A capabilities." },
+        { "name": "gpt-5", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen model with Q&A capabilities." },
+        { "name": "gpt-4o", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenAI next-gen vision model with Q&A capabilities." }
       ]
     },
     "openrouter": {
       "enabled": true,
       "models": [
-        { "name": "anthropic/claude-3.5-sonnet", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Claude 3.5 Sonnet via OpenRouter; strong reasoning." },
-        { "name": "openai/gpt-4o-mini", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenRouter proxy to GPT-4o mini." },
-        { "name": "google/gemini-2.0-flash-lite-001", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.0 Flash Lite via OpenRouter with Q&A capabilities." },
-        { "name": "google/gemini-2.5-flash-lite", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash Lite via OpenRouter with 1M token context window for large document Q&A." },
-        { "name": "google/gemini-2.5-flash", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash via OpenRouter with advanced capabilities." },
-        { "name": "google/gemini-2.5-pro", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Pro via OpenRouter with enhanced reasoning." },
-        { "name": "openai/gpt-oss-20b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenRouter proxy to GPT OSS 20B" },
-        { "name": "openai/gpt-oss-120b", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenRouter proxy to GPT OSS 120B" },
-        { "name": "nvidia/nemotron-nano-9b-v2", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "NVIDIA Nemotron Nano 9B v2; compact high-performance model." }
+        { "name": "anthropic/claude-3.5-sonnet", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Claude 3.5 Sonnet via OpenRouter; strong reasoning." },
+        { "name": "openai/gpt-4o-mini", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenRouter proxy to GPT-4o mini." },
+        { "name": "google/gemini-2.0-flash-lite-001", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.0 Flash Lite via OpenRouter with Q&A capabilities." },
+        { "name": "google/gemini-2.5-flash-lite", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash Lite via OpenRouter with 1M token context window for large document Q&A." },
+        { "name": "google/gemini-2.5-flash", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash via OpenRouter with advanced capabilities." },
+        { "name": "google/gemini-2.5-pro", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Pro via OpenRouter with enhanced reasoning." },
+        { "name": "openai/gpt-oss-20b", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenRouter proxy to GPT OSS 20B" },
+        { "name": "openai/gpt-oss-120b", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "OpenRouter proxy to GPT OSS 120B" },
+        { "name": "nvidia/nemotron-nano-9b-v2", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "NVIDIA Nemotron Nano 9B v2; compact high-performance model." }
       ]
     },
     "anthropic": {
       "enabled": true,
       "models": [
-        { "name": "claude-3-haiku-20240307", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Anthropic Claude 3 Haiku; fast and cost-effective with Q&A support." }
+        { "name": "claude-3-haiku-20240307", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Anthropic Claude 3 Haiku; fast and cost-effective with Q&A support." }
       ]
     },
     "aigateway": {
       "enabled": true,
       "models": [
-        { "name": "openai/gpt-5-nano", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "GPT-5 nano is a high throughput model that excels at simple instruction or classification tasks." },
-        { "name": "gemini-2.0-flash-lite-preview-02-05", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Gemini 2.0 Flash Lite Preview 02-05" },
-        { "name": "mistral-small-2503", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Mistral Small" }
+        { "name": "openai/gpt-5-nano", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "GPT-5 nano is a high throughput model that excels at simple instruction or classification tasks." },
+        { "name": "gemini-2.0-flash-lite-preview-02-05", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Gemini 2.0 Flash Lite Preview 02-05" },
+        { "name": "mistral-small-2503", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Mistral Small" }
 
         
       ]
@@ -68,9 +68,9 @@
     "google": {
       "enabled": true,
       "models": [
-        { "name": "gemini-2.5-flash-lite", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash Lite with fast processing and vision capabilities." },
-        { "name": "gemini-2.5-flash", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash with advanced multimodal capabilities." },
-        { "name": "gemini-2.5-pro", "capabilities": ["summarize", "pdf-summarizer", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Pro with enhanced reasoning and vision support." }
+        { "name": "gemini-2.5-flash-lite", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash Lite with fast processing and vision capabilities." },
+        { "name": "gemini-2.5-flash", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Flash with advanced multimodal capabilities." },
+        { "name": "gemini-2.5-pro", "capabilities": ["summarize", "pdf-summarizer", "pdf-translate", "rewrite", "compose", "planning", "keywords", "sentiment", "vision", "askText", "emailReply", "translate", "meetingNotes", "outline"], "notes": "Google Gemini 2.5 Pro with enhanced reasoning and vision support." }
       ]
     },
     "llamacpp": {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 export type ModelCapability =
   | 'summarize'
   | 'pdf-summarizer'
+  | 'pdf-translate'
   | 'rewrite'
   | 'compose'
   | 'keywords'

--- a/src/routes/v1/demos/pdfTranslateDemo.ts
+++ b/src/routes/v1/demos/pdfTranslateDemo.ts
@@ -1,0 +1,33 @@
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const router = new OpenAPIHono()
+
+const demoRoute = createRoute({
+  method: 'get',
+  path: '/',
+  responses: {
+    200: {
+      description: 'Returns the PDF Translation demo page.',
+      content: {
+        'text/html': {
+          schema: { type: 'string' }
+        }
+      }
+    }
+  },
+  tags: ['Demos']
+})
+
+function getPdfTranslateDemoHtml() {
+  const templatePath = join(process.cwd(), 'src', 'templates', 'pdfTranslateDemo.html')
+  return readFileSync(templatePath, 'utf-8')
+}
+
+router.openapi(demoRoute, (c) => c.html(getPdfTranslateDemoHtml()))
+
+export default {
+  handler: router,
+  mountPath: 'pdf-translate-demo'
+}

--- a/src/routes/v1/pdf-translate.ts
+++ b/src/routes/v1/pdf-translate.ts
@@ -53,6 +53,16 @@ async function handlePdfTranslateRequest(c: Context) {
               provider, 
               model, 
               version: apiVersion
+            },
+            {
+              extraDone: {
+                pdfMetadata: {
+                  title: pdfData.title,
+                  author: pdfData.author,
+                  pages: pdfData.pages,
+                  extractedTextLength: pdfData.text.length,
+                }
+              }
             }
           )
         } catch (error) {

--- a/src/routes/v1/pdf-translate.ts
+++ b/src/routes/v1/pdf-translate.ts
@@ -1,0 +1,161 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
+import { Context } from 'hono'
+import { streamSSE } from 'hono/streaming'
+import { pdfTranslatePrompt } from '../../utils/prompts'
+import { handleError } from '../../utils/errorHandler'
+import { pdfTranslateRequestSchema, pdfTranslateResponseSchema, createPdfTranslateResponse } from '../../schemas/v1/pdf-translate'
+import { processTextOutputRequest } from '../../services/ai'
+import { apiVersion } from './versionConfig'
+import { createFinalResponse } from './finalResponse'
+import { writeTextStreamSSE } from './streamUtils'
+import { extractPDF, truncateText } from '../../utils/pdfExtractor'
+
+const router = new OpenAPIHono()
+
+// Maximum text length to send to the LLM (to avoid token limits)
+const MAX_PDF_TEXT_LENGTH = 50000
+
+async function handlePdfTranslateRequest(c: Context) {
+  try {
+    const { payload, config } = await c.req.json()
+    const provider = config.provider
+    const model = config.model
+    const isStreaming = config.stream || false
+    
+    // Extract PDF content
+    const pdfData = await extractPDF(payload.url)
+    
+    if (!pdfData.text || pdfData.text.length === 0) {
+      throw new Error('No text content found in the PDF')
+    }
+    
+    // Truncate text if it's too long
+    const textToTranslate = truncateText(pdfData.text, MAX_PDF_TEXT_LENGTH)
+    
+    // Create the prompt
+    const prompt = pdfTranslatePrompt(textToTranslate, payload.targetLanguage)
+    
+    // Handle streaming response
+    if (isStreaming) {
+      const result = await processTextOutputRequest(prompt, config)
+      
+      // Set SSE headers
+      c.header('Content-Type', 'text/event-stream')
+      c.header('Cache-Control', 'no-cache')
+      c.header('Connection', 'keep-alive')
+      
+      return streamSSE(c, async (stream) => {
+        try {
+          await writeTextStreamSSE(
+            stream,
+            result,
+            { 
+              provider, 
+              model, 
+              version: apiVersion
+            }
+          )
+        } catch (error) {
+          console.error('Streaming error:', error)
+          try {
+            await stream.writeSSE({
+              data: JSON.stringify({
+                error: error instanceof Error ? error.message : 'Streaming error',
+                done: true
+              })
+            })
+          } catch (writeError) {
+            console.error('Error writing error message to stream:', writeError)
+          }
+        } finally {
+          try {
+            await stream.close()
+          } catch (closeError) {
+            console.error('Error closing stream:', closeError)
+          }
+        }
+      })
+    }
+    
+    // Handle non-streaming response
+    const result = await processTextOutputRequest(prompt, config)
+    const finalResponse = createPdfTranslateResponse(
+      result.text, 
+      provider, 
+      model,
+      {
+        title: pdfData.title,
+        author: pdfData.author,
+        pages: pdfData.pages,
+        extractedTextLength: pdfData.text.length,
+      },
+      {
+        input_tokens: result.usage.promptTokens,
+        output_tokens: result.usage.completionTokens,
+        total_tokens: result.usage.totalTokens,
+      }
+    )
+
+    const finalResponseWithVersion = createFinalResponse(finalResponse, apiVersion)
+
+    return c.json(finalResponseWithVersion, 200)
+  } catch (error) {
+    return handleError(c, error, 'Failed to translate PDF')
+  }
+}
+
+router.openapi(
+  createRoute({
+    path: '/',
+    method: 'post',
+    security: [ { BearerAuth: [] } ],
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: pdfTranslateRequestSchema
+          }
+        }
+      }
+    },
+    responses: {
+      200: {
+        description: 'Returns the translated PDF content.',
+        content: {
+          'application/json': {
+            schema: pdfTranslateResponseSchema
+          }
+        }
+      },
+      401: {
+        description: 'Unauthorized - Bearer token required',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string()
+            })
+          }
+        }
+      },
+      400: {
+        description: 'Bad request - Invalid URL or PDF cannot be processed',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string()
+            })
+          }
+        }
+      }
+    },
+    summary: 'Translate PDF document',
+    description: 'This endpoint receives a PDF URL and uses an LLM to translate the document\'s content to the target language.',
+    tags: ['API']
+  }),
+  handlePdfTranslateRequest as any
+)
+
+export default {
+  handler: router,
+  mountPath: 'pdf-translate'
+}

--- a/src/routes/v1/services.ts
+++ b/src/routes/v1/services.ts
@@ -70,7 +70,7 @@ const modelsSchema = z.object({
   available: z.boolean()
 })
 
-const capabilityEnum = z.enum(['summarize', 'pdf-summarizer', 'rewrite', 'compose', 'keywords', 'sentiment', 'emailReply', 'vision', 'askText', 'translate', 'meetingNotes', 'planning', 'outline'])
+const capabilityEnum = z.enum(['summarize', 'pdf-summarizer', 'pdf-translate', 'rewrite', 'compose', 'keywords', 'sentiment', 'emailReply', 'vision', 'askText', 'translate', 'meetingNotes', 'planning', 'outline'])
 const byProviderSchema = z.record(z.array(z.string()))
 const providerViewSchema = z.record(z.array(z.object({
   name: z.string(),
@@ -82,6 +82,7 @@ const providerViewSchema = z.record(z.array(z.object({
     byCapability: z.object({
       summarize: byProviderSchema,
       'pdf-summarizer': byProviderSchema,
+      'pdf-translate': byProviderSchema,
       rewrite: byProviderSchema,
       compose: byProviderSchema,
       keywords: byProviderSchema,
@@ -115,6 +116,7 @@ async function handleGetModels(c: Context) {
       const byCapability = {
         summarize: getModelsByCapability('summarize'),
         'pdf-summarizer': getModelsByCapability('pdf-summarizer'),
+        'pdf-translate': getModelsByCapability('pdf-translate'),
         rewrite: getModelsByCapability('rewrite'),
         compose: getModelsByCapability('compose'),
         keywords: getModelsByCapability('keywords'),

--- a/src/schemas/v1/pdf-translate.ts
+++ b/src/schemas/v1/pdf-translate.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+import { llmRequestSchema } from './llm'
+
+/**
+ * Body sent by the client.
+ */
+export const payloadSchema = z.object({
+  url: z.string().url('URL must be valid'),
+  targetLanguage: z.string().describe('Target language e.g. "english", "tagalog", "japanese", "korean", "chinese", "french", "spanish"'),
+})
+
+export const pdfTranslateRequestSchema = z.object({
+  payload: payloadSchema,
+  config: llmRequestSchema
+})
+
+/**
+ * Successful response returned to the client.
+ */
+export const pdfTranslateResponseSchema = z.object({
+  translation: z.string(),
+  provider: z.string().optional().describe('The AI service that was actually used'),
+  model: z.string().optional().describe('The model that was actually used'),
+  pdfMetadata: z.object({
+    title: z.string().optional(),
+    author: z.string().optional(),
+    pages: z.number().optional(),
+    extractedTextLength: z.number().describe('Number of characters extracted from the PDF'),
+  }).optional(),
+  usage: z.object({
+    input_tokens: z.number(),
+    output_tokens: z.number(),
+    total_tokens: z.number(),
+  })
+})
+
+export function createPdfTranslateResponse(
+  translation: string, 
+  provider?: string,
+  model?: string,
+  pdfMetadata?: {
+    title?: string,
+    author?: string,
+    pages?: number,
+    extractedTextLength: number,
+  },
+  usage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
+): z.infer<typeof pdfTranslateResponseSchema> {
+  return {
+    translation,
+    provider,
+    model,
+    pdfMetadata,
+    usage,
+  };
+}
+
+export type PdfTranslateReq = z.infer<typeof pdfTranslateRequestSchema>
+export type PdfTranslateRes = z.infer<typeof pdfTranslateResponseSchema>

--- a/src/templates/demos.html
+++ b/src/templates/demos.html
@@ -204,6 +204,52 @@
                 </div>
             </div>
 
+            <!-- PDF Translation Demo Card -->
+            <div class="group relative overflow-hidden bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 h-full flex flex-col">
+                <div class="absolute top-0 right-0 w-32 h-32 bg-gradient-brand opacity-10 rounded-full -mr-16 -mt-16 group-hover:scale-150 transition-transform duration-500"></div>
+                <div class="p-8 flex flex-col h-full">
+                    <div class="w-12 h-12 bg-gradient-brand rounded-xl flex items-center justify-center text-white mb-4">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+                        </svg>
+                    </div>
+                    
+                    <h3 class="text-2xl font-bold text-gray-900 mb-3">PDF Translation</h3>
+                    <p class="text-gray-600 mb-6 leading-relaxed">
+                        Extract and translate content from PDF documents to any language using AI models.
+                    </p>
+                    
+                    <div class="space-y-3 mb-6">
+                        <div class="flex items-center text-sm text-gray-600">
+                            <svg class="w-4 h-4 mr-2 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                            </svg>
+                            PDF text extraction
+                        </div>
+                        <div class="flex items-center text-sm text-gray-600">
+                            <svg class="w-4 h-4 mr-2 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                            </svg>
+                            Multi-language support
+                        </div>
+                        <div class="flex items-center text-sm text-gray-600">
+                            <svg class="w-4 h-4 mr-2 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                            </svg>
+                            Multiple AI providers
+                        </div>
+                    </div>
+                    
+                    <a href="/api/v1/pdf-translate-demo" 
+                       class="mt-auto inline-flex items-center justify-center relative px-6 pr-10 py-3 bg-gradient-brand text-white rounded-lg font-medium hover:opacity-90 transition-opacity duration-200 group">
+                        Try Demo
+                        <svg class="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 group-hover:translate-x-1 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
             <!-- Sentiment Analysis Demo Card -->
             <div class="group relative overflow-hidden bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 h-full flex flex-col">
                 <div class="absolute top-0 right-0 w-32 h-32 bg-gradient-brand opacity-10 rounded-full -mr-16 -mt-16 group-hover:scale-150 transition-transform duration-500"></div>

--- a/src/templates/pdfTranslateDemo.html
+++ b/src/templates/pdfTranslateDemo.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>AI Backends - PDF Summarization Demo</title>
+  <title>AI Backends - PDF Translation Demo</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -134,8 +134,9 @@
     .close-button:hover {
       background: #f9fafb;
     }
-    /* Hide maximize button when in fullscreen; exit with X button */
-    .fullscreen-output #fullscreenButton {
+    /* Hide maximize buttons when in fullscreen; exit with X button */
+    .fullscreen-output #fullscreenButton,
+    .fullscreen-output #fullscreenButtonBottom {
       display: none !important;
     }
   </style>
@@ -182,15 +183,15 @@
         <li><span>/</span></li>
         <li><a href="/api/demos" class="hover:text-gray-700">Demos</a></li>
         <li><span>/</span></li>
-        <li class="text-gray-900 font-medium">PDF Summarization</li>
+        <li class="text-gray-900 font-medium">PDF Translation</li>
       </ol>
     </nav>
 
     <!-- Demo Title and Description -->
     <div class="text-center mb-8">
-      <h1 class="text-3xl font-bold text-gray-900 mb-3">PDF Summarization Demo</h1>
+      <h1 class="text-3xl font-bold text-gray-900 mb-3">PDF Translation Demo</h1>
       <p class="text-lg text-gray-600 max-w-2xl mx-auto">
-        Extract and summarize content from PDF documents using AI models
+        Extract and translate content from PDF documents to any language using AI models
       </p>
     </div>
 
@@ -201,15 +202,21 @@
         <label class="block text-sm font-medium text-gray-700 mb-1">PDF URL</label>
         <input id="pdfUrl" type="url" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple bg-white" placeholder="https://example.com/document.pdf" />
 
+        <div class="mt-4">
+          <label class="block text-sm font-medium text-gray-700 mb-1">Target Language</label>
+          <select id="targetLanguage" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple bg-white">
+            <option value="spanish">Spanish</option>
+            <option value="french">French</option>
+            <option value="german">German</option>
+            <option value="japanese">Japanese</option>
+            <option value="chinese">Chinese</option>
+            <option value="korean">Korean</option>
+            <option value="tagalog">Tagalog</option>
+            <option value="english">English</option>
+          </select>
+        </div>
+
         <div class="grid grid-cols-2 gap-3 mt-4">
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Max Words</label>
-            <input id="maxLength" type="number" min="0" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple" value="200" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Temperature</label>
-            <input id="temperature" type="number" step="0.1" min="0" max="1" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple" value="0.2" />
-          </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
             <select id="provider" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple">
@@ -222,6 +229,10 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Model</label>
             <select id="model" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple"></select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Temperature</label>
+            <input id="temperature" type="number" step="0.1" min="0" max="1" class="w-full p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-purple" value="0.2" />
           </div>
         </div>
 
@@ -238,7 +249,7 @@
         </div>
 
         <div class="mt-4 flex items-center gap-2">
-          <button id="runBtn" class="px-4 py-2 rounded-lg bg-brand-purple text-white hover:bg-[#9935D9]">Summarize PDF</button>
+          <button id="runBtn" class="px-4 py-2 rounded-lg bg-brand-purple text-white hover:bg-[#9935D9]">Translate PDF</button>
           <button id="cancelBtn" class="hidden px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700">Cancel</button>
           <button id="loadSample" class="px-4 py-2 rounded-lg bg-gray-100 text-gray-800 hover:bg-gray-200">Load Sample</button>
         </div>
@@ -265,6 +276,7 @@
             </button>
           </div>
         </div>
+        <button id="openInGoogle" class="mb-3 px-4 py-2 rounded-lg bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50" disabled>Open in Google Translate</button>
         <div id="usageInfo" class="hidden mb-3 text-sm"></div>
         <div id="pdfMetadata" class="hidden mb-3 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm"></div>
         
@@ -273,11 +285,16 @@
           <div class="flex items-center justify-center py-12">
             <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-purple"></div>
           </div>
-          <p class="text-center text-gray-500 mt-4">Processing PDF and generating summary...</p>
+          <p class="text-center text-gray-500 mt-4">Processing PDF and translating content...</p>
         </div>
         
-        <div id="summaryText" class="p-4 rounded-lg bg-gray-50 border border-gray-200 leading-7 text-gray-900"></div>
-        <button id="openInGoogle" class="mt-3 px-4 py-2 rounded-lg bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50" disabled>Open in Google Translate</button>
+        <div id="translationText" class="p-4 rounded-lg bg-gray-50 border border-gray-200 leading-7 text-gray-900"></div>
+        <div class="mt-3 flex items-center gap-2">
+          <button id="openInGoogleBottom" class="px-4 py-2 rounded-lg bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50" disabled>Open in Google Translate</button>
+          <button id="fullscreenButtonBottom" onclick="toggleOutputFullscreen()" class="hidden inline-flex items-center px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg border border-gray-200 hover:bg-gray-200 transition-colors" title="Maximize Output">
+            ⛶ Maximize
+          </button>
+        </div>
       </section>
     </div>
   </main>
@@ -286,7 +303,7 @@
     const samplePayload = {
       payload: {
         url: "https://arxiv.org/pdf/2506.02153",
-        maxLength: 150
+        targetLanguage: "japanese"
       },
       config: {
         provider: "ollama",
@@ -297,7 +314,7 @@
     };
 
     const pdfUrlEl = document.getElementById('pdfUrl');
-    const maxLengthEl = document.getElementById('maxLength');
+    const targetLanguageEl = document.getElementById('targetLanguage');
     const temperatureEl = document.getElementById('temperature');
     const providerEl = document.getElementById('provider');
     const modelEl = document.getElementById('model');
@@ -306,7 +323,7 @@
     const runBtn = document.getElementById('runBtn');
     const cancelBtn = document.getElementById('cancelBtn');
     const loadSampleBtn = document.getElementById('loadSample');
-    const summaryText = document.getElementById('summaryText');
+    const translationText = document.getElementById('translationText');
     const usageInfo = document.getElementById('usageInfo');
     const pdfMetadata = document.getElementById('pdfMetadata');
     const jsonPreview = document.getElementById('jsonPreview');
@@ -314,12 +331,14 @@
     const outputPanel = document.getElementById('outputPanel');
     const copyButton = document.getElementById('copyButton');
     const fullscreenButton = document.getElementById('fullscreenButton');
+    const fullscreenButtonBottom = document.getElementById('fullscreenButtonBottom');
     const openInGoogleBtn = document.getElementById('openInGoogle');
+    const openInGoogleBottomBtn = document.getElementById('openInGoogleBottom');
 
     let abortController = null;
     let eventSource = null;
 
-    // Dynamic model options fetched from backend (pdf-summarizer capability)
+    // Dynamic model options fetched from backend (pdf-translate capability)
     let modelOptions = null;
 
     // Basic Markdown renderer (safe: escapes HTML first)
@@ -422,18 +441,18 @@
       updatePreview();
     }
 
-    async function fetchPdfSummarizerModels() {
+    async function fetchPdfTranslateModels() {
       const headers = {};
       const token = tokenEl.value.trim();
       if (token) headers['Authorization'] = 'Bearer ' + token;
       const res = await fetch('/api/v1/services/models?source=config&view=capability', { headers });
       if (!res.ok) throw new Error('Failed to load models: ' + res.status);
       const data = await res.json();
-      const pdfSummarizer = data && data.byCapability && data.byCapability['pdf-summarizer'];
-      if (!pdfSummarizer || typeof pdfSummarizer !== 'object') throw new Error('Invalid models response');
+      const pdfTranslate = data && data.byCapability && data.byCapability['pdf-translate'];
+      if (!pdfTranslate || typeof pdfTranslate !== 'object') throw new Error('Invalid models response');
       const mapped = {};
-      for (const provider in pdfSummarizer) {
-        const list = Array.isArray(pdfSummarizer[provider]) ? pdfSummarizer[provider] : [];
+      for (const provider in pdfTranslate) {
+        const list = Array.isArray(pdfTranslate[provider]) ? pdfTranslate[provider] : [];
         mapped[provider] = list.map(name => ({ value: name, label: name }));
       }
       return mapped;
@@ -441,7 +460,7 @@
 
     async function initModels() {
       try {
-        modelOptions = await fetchPdfSummarizerModels();
+        modelOptions = await fetchPdfTranslateModels();
         console.log('[Models] Successfully fetched from backend:', Object.keys(modelOptions));
       } catch (e) {
         console.error('[Models] Failed to fetch from backend, using fallback:', e);
@@ -461,7 +480,7 @@
       return {
         payload: {
           url: pdfUrlEl.value.trim(),
-          maxLength: Math.max(0, Number(maxLengthEl.value) || 0)
+          targetLanguage: targetLanguageEl.value
         },
         config: {
           provider: providerEl.value,
@@ -479,7 +498,7 @@
 
     function setFromSample() {
       pdfUrlEl.value = samplePayload.payload.url;
-      maxLengthEl.value = samplePayload.payload.maxLength || 200;
+      targetLanguageEl.value = samplePayload.payload.targetLanguage || 'spanish';
       streamingEl.checked = samplePayload.config.stream !== false;
       providerEl.value = 'ollama';
       updateModelOptions();
@@ -505,30 +524,48 @@
       runBtn.classList.add('hidden');
       cancelBtn.classList.remove('hidden');
 
-      // Clear previous content and show loading state
-      summaryText.innerHTML = '';
-      summaryText.classList.add('hidden');
+      // Clear previous content and show loading state (get fresh references)
+      const translationEl = document.getElementById('translationText');
+      const usageEl = document.getElementById('usageInfo');
+      const metadataEl = document.getElementById('pdfMetadata');
+      const loadingEl = document.getElementById('loadingState');
+      const copyBtn = document.getElementById('copyButton');
+      const fullscreenBtn = document.getElementById('fullscreenButton');
+      const fullscreenBtnBottom = document.getElementById('fullscreenButtonBottom');
+      const googleBtn = document.getElementById('openInGoogle');
+      const googleBottomBtn = document.getElementById('openInGoogleBottom');
+      
+      if (translationEl) {
+        translationEl.innerHTML = '';
+        translationEl.classList.add('hidden');
+      }
       
       // Clear and hide other elements
-      usageInfo.classList.add('hidden');
-      pdfMetadata.classList.add('hidden');
-      setContent(usageInfo, '');
-      setContent(pdfMetadata, '');
+      if (usageEl) {
+        usageEl.classList.add('hidden');
+        setContent(usageEl, '');
+      }
+      if (metadataEl) {
+        metadataEl.classList.add('hidden');
+        setContent(metadataEl, '');
+      }
       
-      // Hide copy and maximize buttons, disable Google Translate button
-      copyButton.classList.add('hidden');
-      fullscreenButton.classList.add('hidden');
-      openInGoogleBtn.disabled = true;
+      // Hide copy and maximize buttons, disable Google Translate buttons
+      if (copyBtn) copyBtn.classList.add('hidden');
+      if (fullscreenBtn) fullscreenBtn.classList.add('hidden');
+      if (fullscreenBtnBottom) fullscreenBtnBottom.classList.add('hidden');
+      if (googleBtn) googleBtn.disabled = true;
+      if (googleBottomBtn) googleBottomBtn.disabled = true;
       
       // Show loading state after clearing everything
-      loadingState.classList.remove('hidden');
+      if (loadingEl) loadingEl.classList.remove('hidden');
 
       const startTime = performance.now();
 
       try {
         if (req.config.stream) {
           // Streaming mode using Server-Sent Events
-          const response = await fetch('/api/v1/pdf-summarizer', {
+          const response = await fetch('/api/v1/pdf-translate', {
             method: 'POST',
             headers,
             body: JSON.stringify(req),
@@ -545,18 +582,29 @@
           if (!contentType || !contentType.includes('text/event-stream')) {
             // Fallback to non-streaming if server didn't return SSE
             const data = await response.json();
-            const summary = data?.summary || data?.data?.summary || '';
+            const translation = data?.translation || data?.data?.translation || '';
             
-            // Hide loading state and show summary
-            loadingState.classList.add('hidden');
-            summaryText.classList.remove('hidden');
-            summaryText.innerHTML = summary ? renderMarkdownSimple(summary) : 'No summary returned.';
+            // Hide loading state and show translation
+            const loadingEl = document.getElementById('loadingState');
+            const translationEl = document.getElementById('translationText');
+            if (loadingEl) loadingEl.classList.add('hidden');
+            if (translationEl) {
+              translationEl.classList.remove('hidden');
+              translationEl.innerHTML = translation ? renderMarkdownSimple(translation) : 'No translation returned.';
+            }
             
             // Show copy and maximize buttons if there's content
-            if (summary) {
-              copyButton.classList.remove('hidden');
-              fullscreenButton.classList.remove('hidden');
-              openInGoogleBtn.disabled = false;
+            if (translation) {
+              const copyBtn = document.getElementById('copyButton');
+              const fullscreenBtn = document.getElementById('fullscreenButton');
+              const fullscreenBtnBottom = document.getElementById('fullscreenButtonBottom');
+              const googleBtn = document.getElementById('openInGoogle');
+              const googleBottomBtn = document.getElementById('openInGoogleBottom');
+              if (copyBtn) copyBtn.classList.remove('hidden');
+              if (fullscreenBtn) fullscreenBtn.classList.remove('hidden');
+              if (fullscreenBtnBottom) fullscreenBtnBottom.classList.remove('hidden');
+              if (googleBtn) googleBtn.disabled = false;
+              if (googleBottomBtn) googleBottomBtn.disabled = false;
             }
             
             // Display PDF metadata if available
@@ -604,17 +652,54 @@
                     // Hide loading state and show content on first chunk
                     if (!firstChunkReceived) {
                       firstChunkReceived = true;
-                      loadingState.classList.add('hidden');
-                      summaryText.classList.remove('hidden');
+                      const loadingEl = document.getElementById('loadingState');
+                      const translationEl = document.getElementById('translationText');
+                      if (loadingEl) loadingEl.classList.add('hidden');
+                      if (translationEl) translationEl.classList.remove('hidden');
                       
                       // Show copy and maximize buttons
-                      copyButton.classList.remove('hidden');
-                      fullscreenButton.classList.remove('hidden');
-                      openInGoogleBtn.disabled = false;
+                      const copyBtn = document.getElementById('copyButton');
+                      const fullscreenBtn = document.getElementById('fullscreenButton');
+                      const fullscreenBtnBottom = document.getElementById('fullscreenButtonBottom');
+                      const googleBtn = document.getElementById('openInGoogle');
+                      const googleBottomBtn = document.getElementById('openInGoogleBottom');
+                      if (copyBtn) copyBtn.classList.remove('hidden');
+                      if (fullscreenBtn) fullscreenBtn.classList.remove('hidden');
+                      if (fullscreenBtnBottom) fullscreenBtnBottom.classList.remove('hidden');
+                      if (googleBtn) googleBtn.disabled = false;
+                      if (googleBottomBtn) googleBottomBtn.disabled = false;
                     }
                     
                     accumulatedText += parsed.chunk;
-                    summaryText.innerHTML = renderMarkdownSimple(accumulatedText);
+                    // Get fresh reference each time in case DOM was replaced by fullscreen
+                    const currentTranslationEl = document.getElementById('translationText');
+                    if (currentTranslationEl) {
+                      currentTranslationEl.innerHTML = renderMarkdownSimple(accumulatedText);
+                      
+                      // Auto-scroll to bottom to show new content
+                      // Use setTimeout with 0 delay to ensure rendering is complete
+                      setTimeout(() => {
+                        // If in fullscreen, scroll the fullscreen-body container
+                        const fullscreenBody = document.querySelector('.fullscreen-body');
+                        const outputPanelEl = document.getElementById('outputPanel');
+                        const isFullscreenMode = outputPanelEl && outputPanelEl.classList.contains('fullscreen-output');
+                        
+                        console.log('[Scroll Debug] isFullscreen:', isFullscreenMode, 'fullscreenBody found:', !!fullscreenBody);
+                        
+                        if (fullscreenBody) {
+                          const beforeScroll = fullscreenBody.scrollTop;
+                          fullscreenBody.scrollTop = fullscreenBody.scrollHeight;
+                          const afterScroll = fullscreenBody.scrollTop;
+                          console.log('[Scroll] Fullscreen - before:', beforeScroll, 'set to:', fullscreenBody.scrollHeight, 'actual after:', afterScroll);
+                        } else if (isFullscreenMode) {
+                          console.error('[Scroll] ERROR: In fullscreen mode but .fullscreen-body not found!');
+                          console.log('[Scroll] outputPanel classes:', outputPanelEl?.className);
+                          console.log('[Scroll] outputPanel children:', outputPanelEl?.children.length);
+                        } else {
+                          console.log('[Scroll] Normal mode - no auto-scroll (prevents flickering)');
+                        }
+                      }, 0);
+                    }
                   }
                   if (parsed.done && parsed.usage) {
                     usage = parsed.usage;
@@ -641,9 +726,13 @@
 
           // If no chunks were received, hide loading state and show empty message
           if (!firstChunkReceived) {
-            loadingState.classList.add('hidden');
-            summaryText.classList.remove('hidden');
-            summaryText.innerHTML = '<span class="text-gray-500">No summary was generated.</span>';
+            const loadingEl = document.getElementById('loadingState');
+            const translationEl = document.getElementById('translationText');
+            if (loadingEl) loadingEl.classList.add('hidden');
+            if (translationEl) {
+              translationEl.classList.remove('hidden');
+              translationEl.innerHTML = '<span class="text-gray-500">No translation was generated.</span>';
+            }
           }
 
           // Display PDF metadata if available
@@ -656,28 +745,31 @@
             displayUsageMetrics(usage, responseTime);
           } else {
             // If no usage data in stream, just show response time
-            usageInfo.classList.remove('hidden');
-            let metricsHtml = '<div class="metrics-container">';
-            metricsHtml += '<div class="grid grid-cols-1 gap-3">';
-            metricsHtml += '<div class="metric-item">' +
-              '<div class="metric-icon">' +
-                '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
-                  '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
-                '</svg>' +
-              '</div>' +
-              '<div>' +
-                '<div class="metric-label">Response</div>' +
-                '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
-              '</div>' +
-            '</div>';
-            metricsHtml += '</div></div>';
-            const metricsDiv = createElement('div');
-            metricsDiv.innerHTML = metricsHtml;
-            setContent(usageInfo, metricsDiv.firstChild);
+            const usageEl = document.getElementById('usageInfo');
+            if (usageEl) {
+              usageEl.classList.remove('hidden');
+              let metricsHtml = '<div class="metrics-container">';
+              metricsHtml += '<div class="grid grid-cols-1 gap-3">';
+              metricsHtml += '<div class="metric-item">' +
+                '<div class="metric-icon">' +
+                  '<svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+                    '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>' +
+                  '</svg>' +
+                '</div>' +
+                '<div>' +
+                  '<div class="metric-label">Response</div>' +
+                  '<div class="metric-value text-orange-600">' + responseTime + ' ms</div>' +
+                '</div>' +
+              '</div>';
+              metricsHtml += '</div></div>';
+              const metricsDiv = createElement('div');
+              metricsDiv.innerHTML = metricsHtml;
+              setContent(usageEl, metricsDiv.firstChild);
+            }
           }
         } else {
           // Non-streaming mode (original implementation)
-          const res = await fetch('/api/v1/pdf-summarizer', {
+          const res = await fetch('/api/v1/pdf-translate', {
             method: 'POST',
             headers,
             body: JSON.stringify(req),
@@ -691,18 +783,29 @@
             throw new Error('Request failed: ' + res.status + ' ' + txt);
           }
           const data = await res.json();
-          const summary = data?.summary || data?.data?.summary || '';
+          const translation = data?.translation || data?.data?.translation || '';
           
-          // Hide loading state and show summary
-          loadingState.classList.add('hidden');
-          summaryText.classList.remove('hidden');
-          summaryText.innerHTML = summary ? renderMarkdownSimple(summary) : 'No summary returned.';
+          // Hide loading state and show translation
+          const loadingEl = document.getElementById('loadingState');
+          const translationEl = document.getElementById('translationText');
+          if (loadingEl) loadingEl.classList.add('hidden');
+          if (translationEl) {
+            translationEl.classList.remove('hidden');
+            translationEl.innerHTML = translation ? renderMarkdownSimple(translation) : 'No translation returned.';
+          }
           
           // Show copy and maximize buttons if there's content
-          if (summary) {
-            copyButton.classList.remove('hidden');
-            fullscreenButton.classList.remove('hidden');
-            openInGoogleBtn.disabled = false;
+          if (translation) {
+            const copyBtn = document.getElementById('copyButton');
+            const fullscreenBtn = document.getElementById('fullscreenButton');
+            const fullscreenBtnBottom = document.getElementById('fullscreenButtonBottom');
+            const googleBtn = document.getElementById('openInGoogle');
+            const googleBottomBtn = document.getElementById('openInGoogleBottom');
+            if (copyBtn) copyBtn.classList.remove('hidden');
+            if (fullscreenBtn) fullscreenBtn.classList.remove('hidden');
+            if (fullscreenBtnBottom) fullscreenBtnBottom.classList.remove('hidden');
+            if (googleBtn) googleBtn.disabled = false;
+            if (googleBottomBtn) googleBottomBtn.disabled = false;
           }
 
           // Display PDF metadata if available
@@ -718,23 +821,41 @@
         }
       } catch (err) {
         // Hide loading state and show error
-        loadingState.classList.add('hidden');
-        summaryText.classList.remove('hidden');
+        const loadingEl = document.getElementById('loadingState');
+        const translationEl = document.getElementById('translationText');
+        const usageEl = document.getElementById('usageInfo');
+        const metadataEl = document.getElementById('pdfMetadata');
         
-        if (err.name === 'AbortError') {
-          summaryText.innerHTML = '<div class="text-amber-600">Request cancelled by user</div>';
-        } else {
-          summaryText.innerHTML = `<div class="text-red-600">Error: ${escapeHtml(err.message || 'Unknown error')}</div>`;
+        if (loadingEl) loadingEl.classList.add('hidden');
+        if (translationEl) {
+          translationEl.classList.remove('hidden');
+          if (err.name === 'AbortError') {
+            translationEl.innerHTML = '<div class="text-amber-600">Request cancelled by user</div>';
+          } else {
+            translationEl.innerHTML = `<div class="text-red-600">Error: ${escapeHtml(err.message || 'Unknown error')}</div>`;
+          }
         }
-        usageInfo.classList.add('hidden');
-        pdfMetadata.classList.add('hidden');
-        setContent(usageInfo, '');
-        setContent(pdfMetadata, '');
         
-        // Hide copy and maximize buttons on error, disable Google Translate
-        copyButton.classList.add('hidden');
-        fullscreenButton.classList.add('hidden');
-        openInGoogleBtn.disabled = true;
+        if (usageEl) {
+          usageEl.classList.add('hidden');
+          setContent(usageEl, '');
+        }
+        if (metadataEl) {
+          metadataEl.classList.add('hidden');
+          setContent(metadataEl, '');
+        }
+        
+        // Hide copy and maximize buttons on error, disable Google Translate buttons
+        const copyBtn = document.getElementById('copyButton');
+        const fullscreenBtn = document.getElementById('fullscreenButton');
+        const fullscreenBtnBottom = document.getElementById('fullscreenButtonBottom');
+        const googleBtn = document.getElementById('openInGoogle');
+        const googleBottomBtn = document.getElementById('openInGoogleBottom');
+        if (copyBtn) copyBtn.classList.add('hidden');
+        if (fullscreenBtn) fullscreenBtn.classList.add('hidden');
+        if (fullscreenBtnBottom) fullscreenBtnBottom.classList.add('hidden');
+        if (googleBtn) googleBtn.disabled = true;
+        if (googleBottomBtn) googleBottomBtn.disabled = true;
       } finally {
         runBtn.classList.remove('hidden');
         cancelBtn.classList.add('hidden');
@@ -745,7 +866,11 @@
     function displayPdfMetadata(metadata) {
       if (!metadata) return;
       
-      pdfMetadata.classList.remove('hidden');
+      // Get fresh reference in case DOM was replaced
+      const pdfMetadataEl = document.getElementById('pdfMetadata');
+      if (!pdfMetadataEl) return;
+      
+      pdfMetadataEl.classList.remove('hidden');
       
       let metadataHtml = '<div class="flex items-center gap-2 mb-2">';
       metadataHtml += '<svg class="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">';
@@ -769,11 +894,15 @@
       }
       metadataHtml += '</div>';
       
-      pdfMetadata.innerHTML = metadataHtml;
+      pdfMetadataEl.innerHTML = metadataHtml;
     }
 
     function displayUsageMetrics(usage, responseTime) {
-      usageInfo.classList.remove('hidden');
+      // Get fresh reference in case DOM was replaced
+      const usageEl = document.getElementById('usageInfo');
+      if (!usageEl) return;
+      
+      usageEl.classList.remove('hidden');
       
       let metricsHtml = '<div class="metrics-container">';
       metricsHtml += '<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">';
@@ -839,7 +968,7 @@
       metricsHtml += '</div></div>';
       const metricsDiv = createElement('div');
       metricsDiv.innerHTML = metricsHtml;
-      setContent(usageInfo, metricsDiv.firstChild);
+      setContent(usageEl, metricsDiv.firstChild);
     }
 
     // Copy and Fullscreen functionality
@@ -885,9 +1014,21 @@
       isFullscreen = false;
       document.removeEventListener('keydown', handleEsc);
       
-      // Rebind button after restore
+      // Rebind buttons after restore
       const btn = document.getElementById('fullscreenButton');
       if (btn) btn.onclick = toggleOutputFullscreen;
+      
+      const btnBottom = document.getElementById('fullscreenButtonBottom');
+      if (btnBottom) btnBottom.onclick = toggleOutputFullscreen;
+      
+      const googleBtn = document.getElementById('openInGoogle');
+      if (googleBtn) googleBtn.addEventListener('click', openInGoogleTranslate);
+      
+      const googleBottomBtn = document.getElementById('openInGoogleBottom');
+      if (googleBottomBtn) googleBottomBtn.addEventListener('click', openInGoogleTranslate);
+      
+      const copyBtn = document.getElementById('copyButton');
+      if (copyBtn) copyBtn.onclick = copyOutput;
     }
 
     function handleEsc(e) {
@@ -899,10 +1040,11 @@
     }
 
     function copyOutput() {
-      const el = document.querySelector('#outputPanel #summaryText') || document.getElementById('summaryText');
+      // Always get fresh reference in case DOM was replaced by fullscreen
+      const el = document.getElementById('translationText');
       if (!el) return;
       const text = el.innerText || '';
-      const btn = document.querySelector('#outputPanel #copyButton') || document.getElementById('copyButton');
+      const btn = document.getElementById('copyButton');
       
       const setCopiedUI = () => {
         if (!btn) return;
@@ -956,9 +1098,12 @@
     }
 
     function openInGoogleTranslate() {
-      const summary = (summaryText.innerText || summaryText.textContent || '').trim();
-      if (!summary) return;
-      const url = 'https://translate.google.com/?sl=auto&tl=en&text=' + encodeURIComponent(summary) + '&op=translate';
+      // Get fresh reference in case DOM was replaced
+      const el = document.getElementById('translationText');
+      if (!el) return;
+      const translation = (el.innerText || el.textContent || '').trim();
+      if (!translation) return;
+      const url = 'https://translate.google.com/?sl=auto&tl=en&text=' + encodeURIComponent(translation) + '&op=translate';
       window.open(url, '_blank', 'noopener');
     }
 
@@ -968,7 +1113,7 @@
     window.copyOutput = copyOutput;
 
     pdfUrlEl.addEventListener('input', updatePreview);
-    maxLengthEl.addEventListener('input', updatePreview);
+    targetLanguageEl.addEventListener('change', updatePreview);
     temperatureEl.addEventListener('input', updatePreview);
     streamingEl.addEventListener('change', updatePreview);
     providerEl.addEventListener('change', () => {
@@ -990,6 +1135,7 @@
     });
     loadSampleBtn.addEventListener('click', () => setFromSample());
     openInGoogleBtn.addEventListener('click', openInGoogleTranslate);
+    openInGoogleBottomBtn.addEventListener('click', openInGoogleTranslate);
 
     // Initialize models from backend, then load sample
     initModels().then(() => setFromSample());

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -439,3 +439,19 @@ ${text}
 </document>
 :`;
 }
+
+/**
+ * System prompt template for PDF translation
+ */
+export function pdfTranslatePrompt(text: string, targetLanguage: string): string {
+  return `Translate the following PDF document content to ${targetLanguage}.
+Preserve the structure and formatting of the text as much as possible.
+Just return the translated text, no other text or explanation. 
+
+Format the output in markdown.
+
+<document>
+${text}
+</document>
+:`;
+}


### PR DESCRIPTION
- Implemented a new endpoint for translating PDF documents, allowing users to extract and translate content to various languages.
- Added necessary schemas for request and response validation.
- Created a demo page for the PDF translation feature, showcasing its functionality.
- Updated existing models and capabilities to include 'pdf-translate'.
- Enhanced the user interface to support the new feature in the demo section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a PDF translation API with streaming, adds the `pdf-translate` capability across models, and ships a new demo page plus minor demo UI tweaks.
> 
> - **API/Backend**:
>   - **New Endpoint**: `POST /api/v1/pdf-translate` with SSE streaming, PDF extraction/truncation, usage metrics, and PDF metadata (`src/routes/v1/pdf-translate.ts`).
>   - **Schemas**: Add `pdf-translate` request/response schemas and factory (`src/schemas/v1/pdf-translate.ts`).
>   - **Prompt**: Add `pdfTranslatePrompt` (`src/utils/prompts.ts`).
>   - **Services Catalog**: Include `pdf-translate` capability in enums and model guidance (`src/routes/v1/services.ts`).
> - **Config**:
>   - **Models**: Add `pdf-translate` capability to multiple models/providers in `src/config/models.json` and type in `src/config/models.ts`.
> - **UI/Demos**:
>   - **New Demo Page**: `src/templates/pdfTranslateDemo.html` and route `src/routes/v1/demos/pdfTranslateDemo.ts`; allowlist `/api/v1/pdf-translate-demo` in `src/app.ts`.
>   - **Demos Index**: Add PDF Translation card/link (`src/templates/demos.html`).
>   - **PDF Summarizer Demo**: Add "Open in Google Translate" button and minor UX improvements (`src/templates/pdfSummarizerDemo.html`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c38f221511cc2ec61e185c3f404e4b503fe5c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->